### PR TITLE
Bump distributed to 2022.04.2, dask-gateway to 2022.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.2" %}
+{% set version = "0.4.3" %}
 
 package:
   name: qhub-dask
@@ -10,9 +10,9 @@ build:
 
 requirements:
   run:
-    - dask ==2021.7.2
-    - distributed ==2021.7.2
-    - dask-gateway ==0.9.0
+    - dask
+    - distributed ==2022.04.2
+    - dask-gateway ==2022.4.0
     - click ==8.0.2
 
 test:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

See https://github.com/Quansight/qhub/issues/1296 for more info; need to bump qhub-dask version there before the issue is closed.

* Also unpinned the dask version, as it gets pinned to the correct version by setting `dask-gateway` and `distributed` versions. See https://github.com/Quansight/qhub/issues/1296#issuecomment-1132955609.
* I tested manually that qhub can be successfully installed locally with these versions; I was able to `import dask.distributed` and `import dask_gateway` without issue